### PR TITLE
Docs: improve image metadata tool references

### DIFF
--- a/OSINT/Image-OSINT.md
+++ b/OSINT/Image-OSINT.md
@@ -32,11 +32,11 @@ exiftool -all= image.jpg
 ```
 
 ### Online Tools
-```
-- Jeffrey's EXIF Viewer: exif.regex.info
-- Pic2Map: pic2map.com
-- FotoForensics: fotoforensics.com
-```
+- [Pic2Map](https://www.pic2map.com/)
+- [FotoForensics](https://fotoforensics.com/)
+- [Metadata Remover Viewer](https://metadataremover.ai/metadata-viewer) — Browser-local EXIF/IPTC/XMP inspection.
+
+> Metadata can be edited or removed; corroborate it with other evidence.
 
 ---
 

--- a/OSINT/Image-OSINT.md
+++ b/OSINT/Image-OSINT.md
@@ -34,7 +34,7 @@ exiftool -all= image.jpg
 ### Online Tools
 - [Pic2Map](https://www.pic2map.com/)
 - [FotoForensics](https://fotoforensics.com/)
-- [Metadata Remover Viewer](https://metadataremover.ai/metadata-viewer) — Browser-local EXIF/IPTC/XMP inspection.
+- [Metadata Remover Viewer](https://metadataremover.ai/metadata-viewer) — Third-party browser-based EXIF/IPTC/XMP inspection tool. Test with non-sensitive files.
 
 > Metadata can be edited or removed; corroborate it with other evidence.
 


### PR DESCRIPTION
## What changed
- Removed the unavailable Jeffrey's EXIF Viewer reference.
- Converted the remaining online tools into clickable Markdown links.
- Added Metadata Remover Viewer for browser-local EXIF/IPTC/XMP inspection.
- Added a reminder that metadata can be edited or removed and should be corroborated.

## Why
The section becomes directly usable and the evidence caveat makes the OSINT workflow more accurate.

Disclosure: I maintain Metadata Remover. This is a transparent resource suggestion; no payment or reciprocal link is requested.